### PR TITLE
docs: add REVIEW-04 layering and dependency boundary review

### DIFF
--- a/docs/reviews/REVIEW-04-layering.md
+++ b/docs/reviews/REVIEW-04-layering.md
@@ -1,0 +1,74 @@
+# REVIEW-04: Layering / Dependency Boundary Review (`src/Exchanges`)
+
+対象: `src/Exchanges/Bitflyer` / `src/Exchanges/Bittrade` / `src/Exchanges/Common`
+
+前提の扱い:
+- REVIEW-01（命名）・REVIEW-02（引数設計）・REVIEW-03（実装フロー/エラー分類/scalar）は再評価しない。
+- 本書は「層責務・依存境界・配置の統一性」に限定した提案レビュー。
+
+## A. 層責務の短い定義案 v1（機械判定向け）
+
+1. **Wire層**は `WireCallSpec` の組み立て・送信のみを担当し、DTOの意味解釈をしない。
+2. **Wire層**は `Raw/Normalized/Adapter` を参照してはならない。
+3. **Raw層**は Wire endpoint 呼び出し + JSONデコード（Raw DTO化）までを担当する。
+4. **Raw層**はドメイン正規化（symbol/period解釈、業務語彙）を持ってはならない。
+5. **Normalized層**は Raw DTO → 正規化DTO 変換と交換所仕様差吸収を担当する。
+6. **Normalized層**は `Wire.Internal` / `Wire.Constants` を直接参照してはならない（endpoint識別子はRaw由来メタを中継）。
+7. **Adapter層**は Facade契約（Contracts）への最終写像とオーケストレーションのみを担当する。
+8. **Adapter層**は `Normalized.Public/Private.Api` と `Contracts` のみを境界依存とし、`Normalized.Internal.*` を直接参照しない。
+9. **PublicClient** は「Facade entry point」に限定し、実処理オーケストレーションは `*MarketApi` 等の専用クラスに委譲する。
+10. **MarketResolver** は Common境界（ExchangeInfo resolver）で共通化し、実装差は ExchangeInfo Provider 側に閉じ込める。
+11. `CallMeta` 構築/例外→Call変換は共通ユーティリティに集約し、各取引所で同一アルゴリズムを重複実装しない。
+12. 依存方向は常に `Adapter -> Normalized -> Raw -> Wire` の単方向とし、逆方向参照は禁止。
+
+## B. 逸脱箇所一覧
+
+- Issue: Publicオーケストレーションの配置が取引所間で非対称（`PublicClient`直書き vs `MarketApi`委譲）。
+- Evidence: `src/Exchanges/Bitflyer/Adapter/Public/Api/PublicClient.cs` (`GetTickerAsync`/`GetBoardAsync`/`GetExecutionsPublicAsync` が resolver + normalized call + mapper まで実施), `src/Exchanges/Bittrade/Adapter/Public/Api/PublicClient.cs` (`Get*Async` は `MarketApi` 委譲のみ), `src/Exchanges/Bittrade/Adapter/Public/Api/MarketApi.cs`（実オーケストレーション本体）。
+- Why it matters: endpoint追加時の実装先・テスト単位（PublicClient単体かMarketApi単体か）が分岐し、横展開の事故率を上げる。
+- Proposed rule: 全取引所で `PublicClient = entrypoint only`、業務オーケストレーションは `MarketApi`（または固定名の同等クラス）に集約する。
+- Severity: P1
+
+- Issue: Adapterが `Normalized.Internal` に直接依存しており、層境界が漏れている。
+- Evidence: `src/Exchanges/Bittrade/Adapter/Public/Api/MarketApi.cs`（`using ...Normalized.Internal.Types`, `...Normalized.Internal.Mappers`）, `src/Exchanges/Bittrade/Adapter/Internal/Mappers/MarketMapper.cs`（`using ...Normalized.Internal.Types`）, `src/Exchanges/Bitflyer/Adapter/Internal/Mappers/MarketMapper.cs`（`using ...Normalized.Internal.Mappers`）。
+- Why it matters: Normalized内部リファクタがAdapter破壊に直結し、境界越え変更の影響範囲が急増する。
+- Proposed rule: Adapterが参照可能なのは `Normalized.Api` と `Normalized.Public/Private.Dtos` のみ。`Normalized.Internal.*` 参照は禁止。
+- Severity: P1
+
+- Issue: Normalizedが `Wire.Constants` を直接参照し、`Normalized -> Raw -> Wire` の段階境界を飛び越えている。
+- Evidence: `src/Exchanges/Bitflyer/Normalized/Public/Api/NormalizedPublicApi.cs`（`using ExchangeApi.Exchanges.Bitflyer.Wire.Constants;`）, `src/Exchanges/Bittrade/Normalized/Public/Api/NormalizedPublicApi.cs`（`using ExchangeApi.Exchanges.Bittrade.Wire.Constants;`）。
+- Why it matters: endpoint ID語彙の変更が Normalized まで波及し、Raw/Wireの改修を局所化できない。
+- Proposed rule: EndpointId/Component語彙はRawが確定して `CallMeta` に載せ、Normalizedは受け渡しのみ行う。
+- Severity: P1
+
+- Issue: `Call`写像ユーティリティがExchange単位で重複し、Common境界が曖昧。
+- Evidence: `src/Exchanges/Bitflyer/Adapter/Internal/ApiCallMapperBase.cs` と `src/Exchanges/Bittrade/Adapter/Internal/ApiCallMapperBase.cs`（同型ロジック）, `src/Exchanges/Common/Application/ExchangeInfo/Adapter/Internal/ExchangeInfoCallMapper.cs`（類似ロジックを別実装）。
+- Why it matters: エラー変換・meta構築方針の微差が将来発生し、取引所ごとの挙動差（監視/障害解析の非対称）を招く。
+- Proposed rule: `Call<TReq,TOk>` 生成テンプレート（FromCall/MapCall/FromException）をCommonへ一本化し、Exchange固有差分はフック関数で注入する。
+- Severity: P2
+
+- Issue: 市場解決エラー組み立て（`MarketResolutionError` / `SymbolNotSupported`）が各実装クラスに重複している。
+- Evidence: `src/Exchanges/Bitflyer/Adapter/Public/Api/PublicClient.cs`（同名ヘルパー）, `src/Exchanges/Bittrade/Adapter/Public/Api/MarketApi.cs`（同名ヘルパー）。
+- Why it matters: 例外分類や `CallMeta` 仕様の変更時に二重修正が必要になり、片側のみ修正の事故が起こりやすい。
+- Proposed rule: resolver起因エラー変換は Common.Adapter ヘルパーへ寄せ、取引所側は operation名だけを渡す。
+- Severity: P2
+
+## C. Commonへ寄せるべき候補 / 取引所に残す拡張点
+
+### Commonへ寄せるべき候補
+- `Call` 写像テンプレート（`MapCall` / `FromCall` / `FromException`）の共通実装。
+- resolver失敗時の `CallMeta` / `CallError` 組み立てヘルパー。
+- Public市場系（ticker/orderbook/executions/candlesticks）のオーケストレーション骨格（resolve -> normalized call -> map -> wrap）。
+- `PublicClient` の責務テンプレート（entrypointのみ）とテスト観点テンプレート。
+
+### 取引所に残す拡張点
+- Raw DTO定義・JSON decode仕様・Wire endpoint定義（Path/Query/HTTP method）。
+- Normalizedの交換所仕様吸収ロジック（status判定、symbol/period変換、型変換）。
+- Adapter最終マッピングの交換所固有差分（Contracts DTOへの個別整形）。
+- ExchangeInfoの静的データ（json）と動的差分取得実装。
+
+---
+
+総評:
+- プロジェクト参照方向（`Adapter -> Normalized -> Raw -> Wire`）自体は健全。
+- ただし「参照可能な語彙境界（Internal / Constants）」と「オーケストレーション配置」の統一が不十分で、将来追加時の判断分岐が残っている。


### PR DESCRIPTION
### Motivation
- Provide a targeted review of layering, dependency boundaries, and placement consistency under `src/Exchanges` to reduce maintenance & onboarding errors when adding exchanges or endpoints. 
- Produce actionable, machine-friendly guidance (short layer definitions, deviation list, and Common-vs-exchange split) without changing production code.

### Description
- Added review document at `docs/reviews/REVIEW-04-layering.md` containing: A) short v1 layer responsibility definitions, B) a formatted deviations list (Issue / Evidence / Why it matters / Proposed rule / Severity), and C) a split of candidates to centralize in `Common` vs exchange-specific extension points. 
- Enumerated concrete deviations observed (PublicClient orchestration placement mismatch, Adapter references to `Normalized.Internal`, `Normalized` referencing `Wire.Constants`, duplicated `Call` mapping utilities and resolver error helpers) and proposed rules for each. 
- No runtime or library code was modified; this change is documentation-only (`docs/reviews/REVIEW-04-layering.md`).

### Testing
- Verified repository state and file presence via `git status --short` which succeeded. 
- Render/inspection checks performed with `nl -ba docs/reviews/REVIEW-04-layering.md | sed -n '1,260p'` which displayed the new file successfully. 
- Staged and committed the new file with `git add` and `git commit -m "docs: add REVIEW-04 layering and boundary assessment"` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e5f57b9883268bb56091df905659)