### PR TITLE
docs: reviews採用ルールをGovernanceへNormative移植とPRテンプレに統一感チェック追加

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## 目的
+
+-
+
+## 変更内容
+
+-
+
+## 統一感チェックリスト
+
+- [ ] EndpointId / 命名規則は既存の正本（TopSpec / Governance / inventory）に一致している
+- [ ] API 境界の Request/Response/Result の使い分けに逸脱がない
+- [ ] 引数順・CancellationToken 命名（`cancellationToken`）・VO/enum 化ルールに逸脱がない
+- [ ] 層責務（Wire/Raw/Normalized/Adapter）と依存方向に逸脱がない
+- [ ] Cross-Exchange で既存の実装形・命名・テスト規約と整合している
+
+## 影響範囲
+
+-
+
+## テスト
+
+-

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -140,3 +140,47 @@ TopSpec および inventory に記載された事実に従う。
   **設計判断の裁定ルール**のみを定める
 * 本書と TopSpec の役割が重なる場合、
   **TopSpec を必ず優先**する
+
+
+## 8. REVIEW 採用ルール（Normative）
+
+本章は `docs/reviews/REVIEW-01`〜`REVIEW-06` のうち、採用済みルールのみを規範化したものである。
+`docs/reviews` 配下は引き続き Reference とし、規範判断は本章を正とする。
+
+### 8.1 命名・語彙（REVIEW-01）
+
+- EndpointId は取引所ごとの inventory を正本とし、取引所横断で同名統一を要求しない。
+- inventory 主表には正規 EndpointId のみを記載し、別名・重複候補は `Aliases` に分離する。
+- `Request/Response` は API 境界 DTO に限定し、`Result` は `CallResult<T>` 用語としてのみ使用する。
+- 外部仕様由来 typo は Wire/inventory に閉じ込め、Contracts や API 境界 DTO へ拡散させない。
+
+### 8.2 引数・型（REVIEW-02）
+
+- `CancellationToken` 引数名は `cancellationToken` に固定し、末尾配置・既定値 `= default` を原則とする。
+- 新規 endpoint では Raw Request/Response から Normalized へ変換する時点で VO/enum 化を完了させる。
+- Normalized 以降で primitive を新規導入してはならない。
+
+### 8.3 実装フロー（REVIEW-03）
+
+- 業務エラー判定は Normalized 層の detector に集約し、`MapOk` の先頭で必ず評価する。
+- Mapping 例外は `CallErrorKind.Mapping` に統一し、`Semantic` へ混在させない。
+- scalar 変換は「必須は Fail-fast、任意は null 許容（不正フォーマットは Mapping）」を標準とする。
+- timestamp 欠損は endpoint ごとの `Required/Optional` ポリシーで固定し、暗黙補完を禁止する。
+
+### 8.4 依存境界（REVIEW-04）
+
+- Adapter は `Normalized.Internal.*` を直接参照してはならない。
+- Normalized は `Wire.Constants` / `Wire.Internal` を直接参照してはならない。
+- `PublicClient` は entrypoint 専用とし、実オーケストレーションは `MarketApi` 側に集約する。
+
+### 8.5 取引所間並列性（REVIEW-05）
+
+- Adapter Public 境界では Request DTO を保持し、`ExchangeClient/PublicClient -> MarketApi` 委譲を取引所間で統一する。
+- Adapter テスト命名は取引所間で同一規約に合わせる。
+
+### 8.6 定数・語彙定義（REVIEW-06）
+
+- HTTP method 等の共通語彙は共通層で定義し、取引所別の文字列直書きを禁止する。
+- 監視・CallMeta で使う Layer/Component 語彙は正本を一元化し、直書きを禁止する。
+- 認証キー名・仕様 typo・raw lexicon は取引所固有定数として取引所配下に閉じ込める。
+

--- a/docs/reviews/README.md
+++ b/docs/reviews/README.md
@@ -29,3 +29,9 @@
 
 - **新規取引所の追加**: まず `REVIEW-05-cross-exchange.md` と `REVIEW-07-boilerplate.md` を参照する。
 - **新規 endpoint の追加**: まず `REVIEW-05-cross-exchange.md` と `REVIEW-07-boilerplate.md` を参照し、必要に応じて `REVIEW-02-parameters.md` / `REVIEW-03-implementation.md` を確認する。
+
+
+## Normative 反映先（採用ルール）
+
+- REVIEW-01〜06 で採用された運用ルールは `docs/governance.md` の「8. REVIEW 採用ルール（Normative）」を正本とする。
+- 各 REVIEW は引き続き検討過程・比較観点を残す **Reference（非規範）** として扱う。


### PR DESCRIPTION
### Motivation
- docs/reviews にある検討メモ群（REVIEW-01〜06）から「採用済みの運用ルールのみ」を規範（Normative）化して判断正本を明確にするため。 
- PR 時のレビュー観点のばらつきを抑えるために、統一感チェックリストをリポジトリの PR テンプレートへ追加するため。 
- 変更は最小差分（docs と `.github` の追加/追記のみ）で行い、既存文書の章立ては維持するため。 

### Description
- `docs/governance.md` に末尾章として `## 8. REVIEW 採用ルール（Normative）` を追記し、REVIEW-01〜06 の採用済ルール（命名・引数/型・実装フロー・依存境界・Cross-Exchange・定数語彙）を規範化しました（追記のみ）。
- `docs/reviews/README.md` に `## Normative 反映先（採用ルール）` を追記して、採用ルールの正本が `docs/governance.md` 第8章であることを明示しました（追記のみ、Reference の扱いは維持）。
- 新規ファイル ` .github/pull_request_template.md` を追加し、PR に使う統一感チェックリスト（EndpointId/命名、Request/Response/Result の扱い、引数順と `cancellationToken`、層責務、Cross-Exchange 整合）を含めました。

### Testing
- 変更内容の差分を `git diff -- docs/reviews/README.md docs/governance.md .github/pull_request_template.md` で確認し、期待どおりの追記/追加があることを確認しました（成功）。
- 作業ツリー状態を `git status --short` で確認し、該当ファイルがコミット対象であることを確認しました（成功）。
- 変更はドキュメントとテンプレートのみでコードは一切変更しておらず、既存自動テスト（ユニット/統合）は実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ef0f07f088326944d1db8818417c1)