### PR TITLE
docs: add Stage8 completion criteria and neutralize SSOT/Inventory wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ExchangeAPI
 
 ExchangeAPI は、複数の暗号資産取引所 API を扱うための実装基盤です。
+ドキュメントの参照起点は `docs/index.md` です。
 
 ## Quick Links
 
@@ -11,7 +12,7 @@ ExchangeAPI は、複数の暗号資産取引所 API を扱うための実装基
 
 ## 安定保証の境界
 
-- 公開安定面は Contract 層のみです。詳細は `docs/contracts/overview.md` を参照してください。
+- 公開安定面は Contract 層のみです。詳細は `docs/contracts/overview.md` と `docs/index.md` を参照してください。
 
 ## Contributions / Development
 

--- a/docs/_references/README.md
+++ b/docs/_references/README.md
@@ -1,0 +1,10 @@
+# _references
+
+このディレクトリは **Informative（参考）専用** です。
+
+- 設計・実装の最終判断には使用しません。
+
+- 本ディレクトリ内に `MUST` / `SHOULD` / 「正本」等の語が現れても、当時の検討記録を保存した表現です。
+
+- 現行判断は `docs/index.md` から辿れる Normative 文書（TopSpec / Contracts / Governance / Process / Exceptions / Inventory）を参照してください。
+

--- a/docs/_references/exchange-parity-policy.md
+++ b/docs/_references/exchange-parity-policy.md
@@ -3,10 +3,9 @@
 本書は **取引所実装間**（例：Bitflyer / Bittrade）において、
 「どこまで統一し、どこから差異を許容するか」を運用上の方針として記録する。
 
-本書は **非規範（Reference）** である。技術規範の正本は `docs/topspec.md`、
-EndpointId の正本は各 `docs/inventory/endpoints-*.md` とする。
+本書は **非規範（Reference）** であり、現行判断の参照先ではない。
 本文中の MUST / MUST NOT / SHOULD / MAY は、当時の方針メモを保存した語であり、
-現行判断の拘束力を持たない。
+現行判断の拘束力を持たない。現行の参照先は `docs/index.md` を起点に確認する。
 
 ## 1. 目的
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,7 @@
 以下は設計正本ではなく、**運用・作業・計画のための補助資料**です。
 
 * `docs/process.md`
+* `docs/stages/stage8.md`
 * `docs/document-plan.md`
 * `docs/utilities.md`
 

--- a/docs/inventory/endpoints-bitflyer.md
+++ b/docs/inventory/endpoints-bitflyer.md
@@ -33,7 +33,7 @@ Note 欄には、以下のような **事実関係（状況）** を記載して
 * 非機能の可能性（non-functional candidate）
 * version 並立の事実
 
-Note 欄には、採用可否・実装判断・設計判断を記載してはならない。
+Note 欄は、採用可否・実装判断・設計判断を扱わず、事実の補足のみを記録する。
 
 ---
 
@@ -86,8 +86,7 @@ Note 欄には、採用可否・実装判断・設計判断を記載してはな
 
 ## Aliases（任意）
 
-本 inventory の `EndpointId` 列に alias を記載してはならない。
-alias を記録する場合は、本セクションに `EndpointId` との対応として記載する。
+本 inventory の `EndpointId` 列には alias を置かず、alias 情報は本セクションで `EndpointId` との対応として記録する。
 
 | EndpointId | Alias | Notes |
 |---|---|---|

--- a/docs/inventory/endpoints-bittrade.md
+++ b/docs/inventory/endpoints-bittrade.md
@@ -38,7 +38,7 @@ Note 欄には、以下のような **事実関係（状況）** を記載して
 * 非機能の可能性（non-functional candidate）
 * version 並立の事実
 
-Note 欄には、採用可否・実装判断・設計判断を記載してはならない。
+Note 欄は、採用可否・実装判断・設計判断を扱わず、事実の補足のみを記録する。
 
 ---
 
@@ -92,8 +92,7 @@ Note 欄には、採用可否・実装判断・設計判断を記載してはな
 
 ## Aliases（任意）
 
-本 inventory の `EndpointId` 列に alias を記載してはならない。
-alias を記録する場合は、本セクションに `EndpointId` との対応として記載する。
+本 inventory の `EndpointId` 列には alias を置かず、alias 情報は本セクションで `EndpointId` との対応として記録する。
 
 | EndpointId | Alias | Notes |
 |---|---|---|

--- a/docs/inventory/endpoints-contracts.md
+++ b/docs/inventory/endpoints-contracts.md
@@ -31,8 +31,8 @@
 * 取引所 endpoint inventory: `docs/inventory/endpoints-*.md`
 * Contracts 契約条文参照: `docs/contracts/contracts.md`
 
-※ 本書は「どの Contracts API がどの取引所 EndpointId に対応しているか」の記録であり、
-　署名の詳細や命名規範そのものは上記文書を参照する。
+※ 本書は「どの Contracts API がどの取引所 EndpointId に対応しているか」の対応一覧を記録する。
+　署名定義や命名ルールの説明は、参照先文書に集約されている。
 
 ---
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -59,6 +59,7 @@
 ### 2.5 Reference（参考）
 - `docs/navigation.md`：用語ナビゲーション（非規範）
 - `docs/utilities.md`：補助的な運用メモ（非規範）
+- `docs/stages/stage8.md`：Stage8 完了判定チェック（非規範）
 - `docs/document-plan.md`：履歴資料（Archive）
 - `docs/reviews/*`：レビュー記録
 - `docs/_references/*`：過去検討・監査ログ（Informative）

--- a/docs/stages/stage8.md
+++ b/docs/stages/stage8.md
@@ -1,0 +1,13 @@
+# Stage 8（完了判定）
+
+## Goal
+
+TopSpec / Contracts / Governance / Process / Exceptions / Inventory の役割が重複せず、設計判断の参照先が常に一意で、README と _references が判断を含まない状態を完成させる。
+
+## DoD（Yes/No）
+
+- [ ] README が導線のみで、SSOT指定や判断文が存在しない（→ docs/index.md / docs/process.md に寄せる）
+- [ ] docs/index.md が Exceptions を「逸脱台帳/決定記録」として案内し、エラー分類とは混同しない
+- [ ] docs/process.md の文書カテゴリ定義と docs 配下の実ファイルが矛盾しない
+- [ ] `docs/_references/` が Normative を匂わせる表現を持たない（informative である旨が明確）
+- [ ] Inventory（`docs/inventory/endpoints-*.md`）が Fact のみで、判断文を含まない


### PR DESCRIPTION
### Motivation
- Remove ambiguity between README and docs by centralizing referral to `docs/index.md` and keeping SSOT/judgment text out of root README.
- Make `docs/inventory/*` and `_references` explicitly informative/fact-only to prevent accidental normative interpretation.
- Provide a concrete, checkable Stage8 completion artifact so the stage can be closed with a deterministic DoD.

### Description
- Added `docs/stages/stage8.md` containing the Stage8 one-sentence goal and a Yes/No DoD checklist. 
- Updated `README.md` to point readers to `docs/index.md` as the documentation entrypoint and kept the stability boundary referral in docs. 
- Registered the Stage8 doc in navigation by updating `docs/index.md` and `docs/process.md` to include `docs/stages/stage8.md` in reference lists. 
- Added `docs/_references/README.md` and neutralized wording in `docs/_references/exchange-parity-policy.md` to mark `_references` as Informative-only. 
- Neutralized prescriptive language in `docs/inventory/endpoints-contracts.md`, `docs/inventory/endpoints-bitflyer.md`, and `docs/inventory/endpoints-bittrade.md` so inventories are explicitly fact/supplement-only (Notes/Aliases wording adjusted). 

### Testing
- Verified the intended diffs with `git diff --cached --unified=3` and inspected file contents with `rg`/`sed`, which confirmed the documentation-only changes (success). 
- Ran repository-wide text searches (`rg`) to validate that `Stage8` and the adjusted references appear in navigation and that `_references` files are tagged informative (success). 
- Attempted `dotnet build`, but the `dotnet` tool is not available in this execution environment so a build could not be performed (skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fea027c808326858461bddf7bd1ed)