### PR TITLE
docs: refine Stage9-1 governance constraints in governance.md

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -198,7 +198,7 @@ TopSpec および inventory に記載された事実に従う。
 ### 9.2 Facade 入力規約
 
 - Facade は `ClientOptions` を必須入力としなければならない（MUST）。
-- Private / Trading 呼び出し時のみ、署名に必要な最小情報として `Credentials` を渡す（MUST）。
+- Facade が認証を必要とする場合、依存してよい情報は `Credentials` に限定する（MUST）。
 - ExecutionContext の塊を、Facade の引数または必須依存として導入してはならない（MUST NOT）。
 
 ### 9.3 ClientOptions の責務境界
@@ -215,6 +215,7 @@ TopSpec および inventory に記載された事実に従う。
 
 - 取引所差分（`Signer` / `Canonicalizer` / `EndpointCatalog` 等）は Core 側に残してよい（MAY）。
 - ただし差分部品を「ExecutionContext の塊」として外部から注入してはならない（MUST NOT）。
+- 差分部品は Facade の内部実装、または取引所モジュール内部に閉じなければならない（SHOULD）。
 
 ### 9.6 Core の責務外（明示）
 


### PR DESCRIPTION
### Motivation

- Clarify Stage9-1 wording so Facade authentication boundary is expressed as a dependency constraint (limit allowed dependency to `Credentials`) rather than forcing a particular passing pattern, preserving constructor/design flexibility while keeping semantics unchanged. 
- Strengthen guidance to avoid accidental re-introduction of ExecutionContext-style bundles by recommending that exchange-difference components remain enclosed within Facade internals or the exchange module.

### Description

- Updated `docs/governance.md` section 9.2 to replace the previous phrasing about passing `Credentials` for Private/Trading calls with a normative requirement that when a Facade requires authentication, the only information it may depend on is `Credentials` (`MUST`).
- Added a normative recommendation to section 9.5 that exchange-difference components must be kept inside the Facade implementation or the exchange module (`SHOULD`), and preserved all other text and `stage9.md` references; this change is documentation-only and affects only `docs/governance.md`.

### Testing

- Ran repository verification commands including `sed -n '1,260p' docs/governance.md`, `nl -ba docs/governance.md | sed -n '190,250p'`, `git status --short`, and `git show --stat --oneline HEAD`, all of which completed successfully.
- No code or unit tests were applicable because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918e9de3148326be7e55da706f9a9e)