### PR TITLE
docs: add Stage9 final merge decision summary

### DIFF
--- a/docs/process/reviews/STAGE9-FINAL-DECISION-20260219.md
+++ b/docs/process/reviews/STAGE9-FINAL-DECISION-20260219.md
@@ -1,0 +1,38 @@
+# STAGE9-FINAL-DECISION-20260219
+
+## 0. 総合判定
+
+- 総合判定: **Merge 可**
+
+## 1. 未解消項目数
+
+- Fatal: **0**
+- NonFatal: **3**
+- Nit: **0**
+
+## 2. Stage9 ブロッカー（あれば）
+
+- なし
+
+## 3. 残存リスク整理
+
+- 技術的リスク:
+  - `REVIEW-06` の提案収束状態が文書上で未固定（要修正 / NonFatal）。
+- 運用的リスク:
+  - DX導線改善が提案止まりのままになりやすい（要修正 / NonFatal）。
+- ドキュメント整合リスク:
+  - Referenceレビュー文書の運用状態（Active/Archived等）の表示統一が未完了（要修正 / NonFatal）。
+
+## 4. Stage9 完了宣言可否
+
+- 完了宣言: **可**
+- 理由:
+  - Phase1 は `NG=0 / Fatal=0` で PASS。
+  - Phase2（7.2必須）は全項目 `[x]` で No なし。
+  - Phase3 は Fatal なし・未解消は NonFatal のみで、Merge不可条件に該当しない。
+
+## 根拠（提出済み Phase）
+
+- Phase1（機械検査結果）: `docs/process/reviews/REVIEW-SUMMARY-20260219-stage9.md`
+- Phase2（7.2 必須チェック）: `docs/process/reviews/REVIEW-MERGE-CHECK-20260219-stage9.md`
+- Phase3（Reference観点レビュー）: `docs/process/reviews/REVIEW-REF-DELTA-20260218-stage9.md`


### PR DESCRIPTION
### Motivation
- Integrate the submitted Phase1 (machine checks), Phase2 (7.2 mandatory checks), and Phase3 (reference review) results into a single Stage9 final merge decision document without adding new investigation.

### Description
- Add `docs/process/reviews/STAGE9-FINAL-DECISION-20260219.md` containing the required 0–4 sections with the integrated verdict `Merge 可`, unresolved counts (Fatal: 0, NonFatal: 3, Nit: 0), blocker list, residual risks, and references to the Phase artifacts.

### Testing
- This is a documentation-only change; no code was modified and existing project tests were observed passing (`dotnet test ExchangeApi.slnx -c Release --no-restore`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699713135e9083269ed8896e57b002d8)